### PR TITLE
systemd support + auto start/stop via udev rules

### DIFF
--- a/80-ds360.rules
+++ b/80-ds360.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="input", ATTRS{id/vendor}=="054c", ATTRS{id/product}=="0ce6", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="ds360.service"
+ACTION=="remove", SUBSYSTEM=="input", ATTRS{id/vendor}=="054c", ATTRS{id/product}=="0ce6", RUN+="kill -9 $(cat /tmp/ds360.pid)"

--- a/80-ds360.rules
+++ b/80-ds360.rules
@@ -1,2 +1,2 @@
 ACTION=="add", SUBSYSTEM=="input", ATTRS{id/vendor}=="054c", ATTRS{id/product}=="0ce6", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="ds360.service"
-ACTION=="remove", SUBSYSTEM=="input", ATTRS{id/vendor}=="054c", ATTRS{id/product}=="0ce6", RUN+="kill -9 $(cat /tmp/ds360.pid)"
+ACTION=="remove", SUBSYSTEM=="input", ATTRS{id/vendor}=="054c", ATTRS{id/product}=="0ce6", RUN+="/usr/bin/ds360-stop.sh"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ ds360: ds360.cpp
 
 install: ds360
 	install -m 555 ds360 $(PREFIX)/bin/
+	install -m 444 ds360.service $(HOME)/.config/systemd/user/
+	systemctl --user daemon-reload
 
 uninstall:
-	rm $(PREFIX)/bin/ds360
+	rm -f $(PREFIX)/bin/ds360
+	rm -f $(HOME)/.config/systemd/user/ds360.service
+	systemctl --user daemon-reload
+	sudo rm -f /usr/lib/udev/rules.d/80-ds360.rules
+	sudo udevadm control --reload

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,5 @@ uninstall:
 	rm -f $(HOME)/.config/systemd/user/ds360.service
 	systemctl --user daemon-reload
 	sudo rm -f /usr/lib/udev/rules.d/80-ds360.rules
+	sudo rm -f /usr/bin/ds360-stop.sh
 	sudo udevadm control --reload

--- a/README.md
+++ b/README.md
@@ -20,8 +20,17 @@ cd ds360
 make
 ```
 ## Usage
+#### Starting the process in terminal, press CTRL+C to stop
 ```
 ./ds360
+```
+#### Starting ds360.service manually, controller must be connected
+```
+systemctl start --user ds360.service
+```
+#### Automatically start ds360.service via udev rule when controller connects
+```
+./add-udev-rule.sh
 ```
 ## How to install
 ```

--- a/add-udev-rule.sh
+++ b/add-udev-rule.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 sudo cp 80-ds360.rules /usr/lib/udev/rules.d/
+sudo cp ds360-stop.sh /usr/bin/
+sudo chmod 555 /usr/bin/ds360-stop.sh
 sudo udevadm control --reload

--- a/add-udev-rule.sh
+++ b/add-udev-rule.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sudo cp 80-ds360.rules /usr/lib/udev/rules.d/
+sudo udevadm control --reload

--- a/ds360-stop.sh
+++ b/ds360-stop.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+kill -9 $(cat /tmp/ds360.pid)

--- a/ds360.cpp
+++ b/ds360.cpp
@@ -76,10 +76,30 @@ std::string get_device(std::string device_vid, std::string device_pid)
     return device_path;
 }
 
+void create_pid_file() {
+    std::string pid_file = "/tmp/ds360.pid";
+    pid_t pid = getpid();
+    std::ofstream file_output;
+    auto pid_str = std::to_string(pid);
+
+    std::cout << "pid: " << pid_str << std::endl;
+    file_output.open(pid_file.c_str());
+
+    if (!file_output.is_open())
+    {
+        std::cerr << "file_output.open >> " << std::strerror(errno) << std::endl;
+        throw -2;
+    }
+
+    file_output << pid_str.c_str() << std::endl;
+    file_output.close();
+}
+
 int main(int argc, char* argv[])
 {
     try
     {
+        create_pid_file();
         std::string event_path = get_device("054c", "0ce6");
         if (argc < 2) {
             execvp("xboxdrv", 

--- a/ds360.service
+++ b/ds360.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=ds360 service
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/ds360
+
+[Install]
+WantedBy=default.target

--- a/remove-udev-rule.sh
+++ b/remove-udev-rule.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sudo rm /usr/lib/udev/rules.d/80-ds360.rules
+sudo udevadm control --reload

--- a/remove-udev-rule.sh
+++ b/remove-udev-rule.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-sudo rm /usr/lib/udev/rules.d/80-ds360.rules
+sudo rm -f /usr/lib/udev/rules.d/80-ds360.rules
+sudo rm -f /usr/bin/ds360-stop.sh
 sudo udevadm control --reload


### PR DESCRIPTION
### systemd support
- Added `systemd` service support
    - It's a user service so it does not require `root` 
        - `systemctl start --user ds360.service`
    - Before you either had to keep a terminal window open or use  `&` symbol to tell the shell to run the command in the background and remember the `pid` to kill later
- `ds360` now stores `pid` in `/tmp/ds360.pid`

### udev support
- Added `udev` rule support to automatically start/stop `ds360.service` when the controller connects/disconnects
- This is optional, requires `root` to setup, it is not part of `make install`. Added two scripts to add/remove rules
     - `add-udev-rule.sh` / `remove-udev-rule.sh`