### PR TITLE
Create required directories when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ ds360: ds360.cpp
 	g++ -Wall -o ds360 ds360.cpp
 
 install: ds360
-	install -m 555 ds360 $(PREFIX)/bin/
-	install -m 444 ds360.service $(HOME)/.config/systemd/user/
+	install -m 555 -D ds360 -t "$(PREFIX)/bin/"
+	install -m 444 -D ds360.service -t "$(HOME)/.config/systemd/user/"
 	systemctl --user daemon-reload
 
 uninstall:
-	rm -f $(PREFIX)/bin/ds360
-	rm -f $(HOME)/.config/systemd/user/ds360.service
+	rm -f "$(PREFIX)/bin/ds360"
+	rm -f "$(HOME)/.config/systemd/user/ds360.service"
 	systemctl --user daemon-reload
 	sudo rm -f /usr/lib/udev/rules.d/80-ds360.rules
 	sudo rm -f /usr/bin/ds360-stop.sh


### PR DESCRIPTION
I noticed `make install` wasn't working for me. Turned out the `install` command wasn't creating the target directories `$(PREFIX)/bin/` and `$(HOME)/.config/systemd/user/` because the `-D` flag wasn't used.

- Use [`install`'s `-D` flag](https://linux.die.net/man/1/install) to create any destination directories that don't exist. Similar to `mkdir -p`.
- Also wrapped target paths in double quotes in case `PREFIX` or `HOME` variables contain whitespace, etc.